### PR TITLE
Make exec, service and file_line explicitly require the ufw package.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,20 +18,23 @@ class ufw (
   exec { 'ufw-deny':
     command => 'ufw default deny',
     unless  => 'ufw status verbose | grep -q "Default: deny (incoming)"',
-    path    => '/bin:/usr/bin:/sbin:/usr/sbin'
+    path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+    require => Package['ufw']
   }
 
   # Enable UFW
   exec { 'ufw-enable':
     command => 'ufw --force enable',
     unless  => 'ufw status | grep -q "Status: active"',
-    path    => '/bin:/usr/bin:/sbin:/usr/sbin'
+    path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+    require => Package['ufw']
   }
 
   # Define service
   service { 'ufw':
     ensure => 'running',
-    enable => true
+    enable => true,
+    require => Package['ufw']
   }
 
   # Disable IPv6
@@ -39,7 +42,8 @@ class ufw (
     line   => $_ipv6,
     match  => '^IPV6=',
     path   => '/etc/default/ufw',
-    notify => Service['ufw']
+    notify => Service['ufw'],
+    require => Package['ufw']
   }
 
 }


### PR DESCRIPTION
In my testing of this module.   When run on machines that don't already have the ufw package installed.   Sometimes the exec rules are run prior to the package install occurring.   This cause setup to not be fully completed until the next puppet run.    This updates adds explicit require entries to ensure the package always gets installed first.
